### PR TITLE
Add support for single value queries

### DIFF
--- a/TempoIQ/Json/TempoIQSerializer.cs
+++ b/TempoIQ/Json/TempoIQSerializer.cs
@@ -29,7 +29,8 @@ namespace TempoIQ.Json
                     new SelectionConverter(),
                     new SelectorConverter(),
                     new SelectorTypeConverter(),
-                    new ZonedDateTimeConverter()
+                    new ZonedDateTimeConverter(),
+                    new NullableZonedDateTimeConverter()
                 };
             }
         }

--- a/TempoIQ/Queries/Action.cs
+++ b/TempoIQ/Queries/Action.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using NodaTime;
+using TempoIQ.Json;
 
 namespace TempoIQ.Queries
 {
@@ -93,7 +94,7 @@ namespace TempoIQ.Queries
     /// The Action object for specifying latest-value queries 
     /// </summary>
 	[JsonObject]
-	public class SingleValueAction : Action
+	public class SingleValueAction
 	{
         /// <summary>
         /// Gets the name of the action-type.
@@ -109,22 +110,37 @@ namespace TempoIQ.Queries
         [JsonProperty(PropertyName = "limit", NullValueHandling = NullValueHandling.Ignore)]
         public int? Limit { get; set; }
 
+        /// <summary>
+        /// The function which determines which single value the query yields
+        /// </summary>
+        [JsonConverter(typeof(DirectionFunctionConverter))]
+        [JsonProperty(PropertyName = "function", NullValueHandling = NullValueHandling.Ignore)]
+        public DirectionFunction Function { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the single value query <see cref="TempoIQ.Queries.SingleValueAction"/> includes the devices selected as well as the data.
         /// </summary>
         /// <value><c>true</c> if include selection; otherwise, <c>false</c>.</value>
-        [JsonProperty("include_selection")]
+        [JsonProperty(PropertyName = "include_selection", NullValueHandling = NullValueHandling.Ignore)]
         public bool IncludeSelection { get; set; }
+
+        /// <summary>
+        /// The timestamp, if any, passed to the direction function to determine which single value is returned
+        /// </summary>
+        /// <value><c>null</c> if <c>Latest</c> or <c>Earliest</c>, some <c>ZonedDateTime</c> otherwise</value>
+        [JsonProperty(PropertyName = "timestamp", NullValueHandling = NullValueHandling.Ignore)]
+        public ZonedDateTime? Timestamp { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TempoIQ.Queries.SingleValueAction"/> class.
         /// </summary>
         /// <param name="includeSelection">If set to <c>true</c> include selection.</param>
-        public SingleValueAction(bool includeSelection = false, int? limit = null)
+        public SingleValueAction(DirectionFunction function = DirectionFunction.Latest, ZonedDateTime? timestamp = null, bool includeSelection = false, int? limit = null)
         {
             this.IncludeSelection = includeSelection;
             this.Limit = limit;
+            this.Function = function;
+            this.Timestamp = timestamp;
         }
     }
 }

--- a/TempoIQ/Queries/DirectionFunction.cs
+++ b/TempoIQ/Queries/DirectionFunction.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TempoIQ.Queries
+{
+    public enum DirectionFunction
+    {
+        /// <summary>
+        /// The point with the latest timestamp. Does not take a timestamp as an argument
+        /// </summary>
+        Latest,
+
+        /// <summary>
+        /// The point with the earliest timestamp. Does not take a timestamp as an argument
+        /// </summary>
+        Earliest,
+
+        /// <summary>
+        /// The point with the timestamp nearest the one provided. Takes a timestamp as an argument
+        /// </summary>
+        Nearest,
+
+        /// <summary>
+        /// The point with the nearest timestamp before the one provided. Takes a timestamp as an argument
+        /// </summary>
+        Before,
+        
+        /// <summary>
+        /// The point with the nearest timestamp after the one provided. Takes a timestamp as an argument
+        /// </summary>
+        After,
+
+        /// <summary>
+        /// The point with the exact timestamp provided if any. Takes a timestamp as an argument
+        /// </summary>
+        Exact
+    }
+}

--- a/TempoIQ/Results/PageLoader.cs
+++ b/TempoIQ/Results/PageLoader.cs
@@ -17,6 +17,8 @@ namespace TempoIQ.Results
         private string EndPoint { get; set; }
         private string ContentType { get; set; }
         private string[] MediaTypeVersion { get; set; }
+        private Segment<T> OnDeck { get; set; }
+        private bool HasBench { get; set; }
 
         public PageLoader(Executor runner, Segment<T> first, string endPoint, string contentType, params string[] mediaTypeVersion)
         {
@@ -26,6 +28,7 @@ namespace TempoIQ.Results
             this.EndPoint = endPoint;
             this.ContentType = contentType;
             this.MediaTypeVersion = mediaTypeVersion;
+            this.HasBench = true;
         }
 
         object System.Collections.IEnumerator.Current

--- a/TempoIQ/TempoIQ.csproj
+++ b/TempoIQ/TempoIQ.csproj
@@ -57,6 +57,7 @@
   <ItemGroup>
     <Compile Include="Queries\Action.cs" />
     <Compile Include="Client.cs" />
+    <Compile Include="Queries\DirectionFunction.cs" />
     <Compile Include="Results\Cursor.cs" />
     <Compile Include="Credentials.cs" />
     <Compile Include="Models\Device.cs" />


### PR DESCRIPTION
Extend the `Client.Single` method to allow for various actions: earliest, latest, before, after, nearest, and exact matches